### PR TITLE
conference格式修正

### DIFF
--- a/template/uestcthesis.bst
+++ b/template/uestcthesis.bst
@@ -1994,7 +1994,8 @@ FUNCTION {conference}
   new.block
   format.conference.title output
   new.block
-      publisher ", " * address * output
+      booktitle output
+	    address  output
       year output
       format.comma.pages output
   new.block
@@ -2005,7 +2006,8 @@ FUNCTION {conference}
   new.block
   format.conference.title output
   new.block
-      publisher ", " * address * output
+      booktitle output
+	    address  output
       year output
       format.comma.pages output
   new.block


### PR DESCRIPTION
将booktitle设定为论文集名称，符合标准BiBTeX规范，避免与publisher条目出现冲突。
论文脚本编译也正常。