### PR TITLE
定理环境修正

### DIFF
--- a/template/uestcthesis.cls
+++ b/template/uestcthesis.cls
@@ -696,19 +696,19 @@ pdfkeywords={\@pdfckeywords}%在pdf元信息中加入关键字
 \theoremheaderfont{\normalfont \bfseries \hspace*{2em}}%设置缩进
 \theoremseparator{\enskip}%分隔符是一个空格
 \theoremsymbol{}%定义环境结束符，下同
-\newtheorem{dingyi}{定义}[section]
+\newtheorem{dingyi}{定义}[chapter]
 \def\enddingyi{\quad\@endtheorem}%修正环境中最后一个字符不是英文字符时，不显示结束符的BUG。下同。
 \theoremsymbol{}
-\newtheorem{gongli}{公理}[section]
+\newtheorem{gongli}{公理}[chapter]
 \def\endgongli{\quad\@endtheorem}
-\theoremsymbol{■}
-\newtheorem{dingli}{定理}[section]
+%\theoremsymbol{■}
+\newtheorem{dingli}{定理}[chapter]
 \def\enddingli{\quad\@endtheorem}
-\theoremsymbol{■}
-\newtheorem{yinli}{引理}[section]
+%\theoremsymbol{■}
+\newtheorem{yinli}{引理}[chapter]
 \def\endyinli{\quad\@endtheorem}
 \theoremstyle{nonumberplain}
-\theoremsymbol{■}
+\theoremsymbol{$\blacksquare$}
 \newtheorem{zhengming}{证明}
 \def\endzhengming{\quad\@endtheorem}
 \RequirePackage[numbers,sort&compress]{natbib}


### PR DESCRIPTION
按照学校2016年的学位论文撰写规范，定理引理等后面若有证明，则在证明结束处加上黑色方块表示证明完毕。
如果没有证明，则无需添加该方块字符，因此将模板中的两处\theoremsymbol{■}注释掉了。
此外还有两处修改：
1.将定理环境的编号模式section改为chapter；（学校的规范中给的是“定理 X.X”、“引理 X.X”）
2.将模板中的证毕方块字符■替换为 $\blacksquare$。

论文脚本编译正常。
